### PR TITLE
Language Argument and fixed tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.8
+  - "4.1"

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+0.0.7 / 2015-11-1
+====================
+* query non-english wikipedias with lang argument
+
 0.0.6 / 2013-06-23
 ====================
 * return non-parsed formats other than JSON

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wikipedia-js [![Build Status](https://travis-ci.org/kenshiro-o/wikipedia-js.png?branch=master)](https://travis-ci.org/kenshiro-o/wikipedia-js)
 
   wikipedia-js is a simple client that enables you to query Wikipedia articles in english. 
-  The format of the result is among `json`, `jsonfm`, `wddx`, `wddxfm`, `xml`, `rawfm`.
+  The format of the result is among `json`, `html`, `xml`, `rawfm`.
   In the case of `html` the result is formatted in basic HTML. You can retrieve either a summary of an article (i.e. before the table of contents) or a full article
 
 ## Rationale

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # wikipedia-js [![Build Status](https://travis-ci.org/kenshiro-o/wikipedia-js.png?branch=master)](https://travis-ci.org/kenshiro-o/wikipedia-js)
 
-  wikipedia-js is a simple client that enables you to query Wikipedia articles in english. 
+  wikipedia-js is a simple client that enables you to query Wikipedia articles. 
   The format of the result is among `json`, `html`, `xml`, `rawfm`.
-  In the case of `html` the result is formatted in basic HTML. You can retrieve either a summary of an article (i.e. before the table of contents) or a full article
+  In the case of `html` the result is formatted in basic HTML. You can retrieve either a summary of an article (i.e. before the table of contents) or a full article.
 
 ## Rationale
 
@@ -20,7 +20,10 @@
     var query = "Napoleon Bonaparte";
     // if you want to retrieve a full article set summaryOnly to false.
     // Full article retrieval and parsing is still beta
-    var options = {query: query, format: "html", summaryOnly: true};
+    // lang takes a language code in the format they appear in the URL. 
+    // default: 'en' 
+    // examples: 'simple','fr','zh','fa'
+    var options = {query: query, format: "html", summaryOnly: true, lang: "en"};
     wikipedia.searchArticle(options, function(err, htmlWikiText){
       if(err){
         console.log("An error occurred[query=%s, error=%s]", query, err);
@@ -51,12 +54,6 @@
      {{Gutenberg|no=3567|name=Memoirs of Napoleon}} -> <a href="http://www.gutenberg.org/ebooks/3567">Memoirs Of Napoleon</a>
 
 
-## Additional features
-
-  The following features will be added soon:
-  - parse metadata
-  - return other formats i.e.: `yaml`, `php`, `txt`, `dbg`, `dump`
-  - improve performance
 
 ## Acknowledgement
   I would like to thank the following people for their contribution to this project:

--- a/lib/constants/wikiConstants.js
+++ b/lib/constants/wikiConstants.js
@@ -1,5 +1,6 @@
-module.exports.WIKIPEDIA_EN_URL = "http://simple.wikipedia.org";
-module.exports.WIKIPEDIA_EN_URL_WIKI = "http://simple.wikipedia.org/wiki/";
-module.exports.WIKIPEDIA_EN_API_URL = "http://simple.wikipedia.org/w/api.php";
+module.exports.WIKIPEDIA_STUB = "http://"
+module.exports.WIKIPEDIA_URL = ".wikipedia.org";
+module.exports.WIKIPEDIA_URL_WIKI = ".wikipedia.org/wiki/";
+module.exports.WIKIPEDIA_API_URL = ".wikipedia.org/w/api.php";
 module.exports.PROJECT_GUTENBERG_EBOOK_BASE_URL = "http://www.gutenberg.org/ebooks/";
 module.exports.WORLDCAT_IDENTITY_LINK = "http://www.worldcat.org/identities/";

--- a/lib/constants/wikiConstants.js
+++ b/lib/constants/wikiConstants.js
@@ -1,5 +1,5 @@
-module.exports.WIKIPEDIA_EN_URL = "http://en.wikipedia.org";
-module.exports.WIKIPEDIA_EN_URL_WIKI = "http://en.wikipedia.org/wiki/";
-module.exports.WIKIPEDIA_EN_API_URL = "http://en.wikipedia.org/w/api.php";
+module.exports.WIKIPEDIA_EN_URL = "http://simple.wikipedia.org";
+module.exports.WIKIPEDIA_EN_URL_WIKI = "http://simple.wikipedia.org/wiki/";
+module.exports.WIKIPEDIA_EN_API_URL = "http://simple.wikipedia.org/w/api.php";
 module.exports.PROJECT_GUTENBERG_EBOOK_BASE_URL = "http://www.gutenberg.org/ebooks/";
 module.exports.WORLDCAT_IDENTITY_LINK = "http://www.worldcat.org/identities/";

--- a/lib/converter/wikiToHTMLConverter.js
+++ b/lib/converter/wikiToHTMLConverter.js
@@ -1,5 +1,4 @@
 var constants = require("./../constants/wikiConstants");
-
 var STRONG_EM_STYLE_REGEX = /[']{5}\s*([^']+'[^']+|[^']*)\s*[']{5}/g;
 var STRONG_STYLE_REGEX = /[']{3}\s*([^']+'[^']+|[^']*)\s*[']{3}/g;
 var EM_STYLE_REGEX = /[']{2}\s*([^']+'[^']+|[^']*)\s*[']{2}/g;
@@ -15,178 +14,178 @@ var REFERENCES_TO_IGNORE = /<ref[^\/]*\/>|<ref[^>]*>[^<]*<\/ref>/g;
 var COMMENTS_REGEX = /<!--\s*[^-]*-->/g;
 
 var LANGUAGE_MAP = {
-  "lang-fr": "French",
-  "lang-es": "Spanish",
-  "lang-en": "English",
-  "lang-it": "Italian"
+    "lang-fr": "French",
+    "lang-es": "Spanish",
+    "lang-en": "English",
+    "lang-it": "Italian"
 };
 
-function convertLineToHTML(line) {
-  var matched = false;
+function convertLineToHTML(line, lang) {
+    var matched = false;
 
-  line = line.replace(CITATION_REFERENCE_REGEX, function (match, matchedSequence) {
-    var sections = matchedSequence.split("|");
-    var refType = sections.shift();
-    var tile = "";
-    var elem = '<span class="reference" data-type="' + refType + '"';
-    sections.forEach(function (section) {
-      var keyValue = section.split("=");
-      if (keyValue[0] !== "title") {
-        elem += ' data-' + keyValue[0] + '="' + keyValue[1] + '"';
-      }else{
-        tile = keyValue[1];
-      }
+    line = line.replace(CITATION_REFERENCE_REGEX, function(match, matchedSequence) {
+        var sections = matchedSequence.split("|");
+        var refType = sections.shift();
+        var tile = "";
+        var elem = '<span class="reference" data-type="' + refType + '"';
+        sections.forEach(function(section) {
+            var keyValue = section.split("=");
+            if (keyValue[0] !== "title") {
+                elem += ' data-' + keyValue[0] + '="' + keyValue[1] + '"';
+            } else {
+                tile = keyValue[1];
+            }
+        });
+
+        elem += ">" + tile + "</span>";
+        matched = true;
+        return elem;
     });
 
-    elem += ">" + tile + "</span>";
-    matched = true;
-    return elem;
-  });
+    //  if(matched){
+    //    //Short-circuit here, since we have matched a reference
+    //    return line;
+    //  }
 
-//  if(matched){
-//    //Short-circuit here, since we have matched a reference
-//    return line;
-//  }
+    line = line.replace(GUTENBERG_REFERENCE_REGEX, function(match, matchedSequence) {
+        // e.g. {Gutenberg|no=3567|name=Memoirs of Napoleon}}
+        var sections = matchedSequence.split("|");
+        //Get rid of the "Gutenberg"
+        sections.shift();
+        var gutenbergNb = 0;
+        var title = "";
+        sections.forEach(function(section) {
+            var keyValue = section.split("=");
+            if (keyValue[0] === "name") {
+                title = keyValue[1];
+            } else if (keyValue[0] === "no") {
+                gutenbergNb = keyValue[1];
+            }
+        });
+        matched = true;
 
-  line = line.replace(GUTENBERG_REFERENCE_REGEX, function(match, matchedSequence){
-  // e.g. {Gutenberg|no=3567|name=Memoirs of Napoleon}}
-    var sections = matchedSequence.split("|");
-    //Get rid of the "Gutenberg"
-    sections.shift();
-    var gutenbergNb = 0;
-    var title = "";
-    sections.forEach(function(section){
-      var keyValue = section.split("=");
-      if(keyValue[0] === "name"){
-        title = keyValue[1];
-      }else if(keyValue[0] === "no"){
-        gutenbergNb = keyValue[1];
-      }
+        return '<a href="' + constants.PROJECT_GUTENBERG_EBOOK_BASE_URL + gutenbergNb + '">' + title + "</a>";
     });
-    matched = true;
 
-    return '<a href="' + constants.PROJECT_GUTENBERG_EBOOK_BASE_URL + gutenbergNb + '">' + title + "</a>";
-  });
+    //  if(matched){
+    //    return line;
+    //  }
 
-//  if(matched){
-//    return line;
-//  }
+    line = line.replace(WORLDCAT_REFERENCE_REGEX, function(natch, matchedSequence) {
+        // e.g. {{worldcat id|id=lccn-n79-54933}}
+        var idIndex = matchedSequence.indexOf("id=");
+        var id = matchedSequence.substring(idIndex + 3);
 
-  line = line.replace(WORLDCAT_REFERENCE_REGEX, function(natch, matchedSequence){
-    // e.g. {{worldcat id|id=lccn-n79-54933}}
-    var idIndex = matchedSequence.indexOf("id=");
-    var id = matchedSequence.substring(idIndex + 3);
+        matched = true;
+        return '<a href="' + constants.WORLDCAT_IDENTITY_LINK + id + '">Worldcat reference</a>';
+    });
 
-    matched = true;
-    return '<a href="' + constants.WORLDCAT_IDENTITY_LINK + id + '">Worldcat reference</a>';
-  });
-
-//  if(matched){
-//    return line;
-//  }
+    //  if(matched){
+    //    return line;
+    //  }
 
 
 
 
-  line = line.replace(HEADING_REGEX, function (match, subMatch1) {
-    var index = match.indexOf(subMatch1);
-    var lastIndex = match.length - index;
-    var headingTag = "h" + index;
-    return "<" + headingTag + ">" + match.substring(index, lastIndex) + "</" + headingTag + ">";
-  });
+    line = line.replace(HEADING_REGEX, function(match, subMatch1) {
+        var index = match.indexOf(subMatch1);
+        var lastIndex = match.length - index;
+        var headingTag = "h" + index;
+        return "<" + headingTag + ">" + match.substring(index, lastIndex) + "</" + headingTag + ">";
+    });
 
-  // cascading order of quote matching such that we don't match a lesser number
-  // of quotes inside a larger number
-  line = line.replace(STRONG_EM_STYLE_REGEX, function (match, subMatch1) {
-    return "<strong><em>" + subMatch1 + "</em></strong>";
-  });
+    // cascading order of quote matching such that we don't match a lesser number
+    // of quotes inside a larger number
+    line = line.replace(STRONG_EM_STYLE_REGEX, function(match, subMatch1) {
+        return "<strong><em>" + subMatch1 + "</em></strong>";
+    });
 
-  line = line.replace(STRONG_STYLE_REGEX, function (match, subMatch1) {
-    return "<strong>" + subMatch1 + "</strong>";
-  });
+    line = line.replace(STRONG_STYLE_REGEX, function(match, subMatch1) {
+        return "<strong>" + subMatch1 + "</strong>";
+    });
 
-  line = line.replace(EM_STYLE_REGEX, function (match, subMatch1) {
-    return "<em>" + subMatch1 + "</em>";
-  });
+    line = line.replace(EM_STYLE_REGEX, function(match, subMatch1) {
+        return "<em>" + subMatch1 + "</em>";
+    });
 
-  line = line.replace(LINK_REGEX, function (match, matchedLink) {
-    var underscoreLink = "";
+    line = line.replace(LINK_REGEX, function(match, matchedLink) {
+        var underscoreLink = "";
 
-    if(matchedLink.indexOf("Category:") === 0){
-      var elem = '<span class="category">';
-      var colonIndex = matchedLink.indexOf(":");
-      var category = matchedLink.substring(colonIndex + 1);
-      var link = '<a href="' + constants.WIKIPEDIA_EN_URL_WIKI + 'Category:' + category.replace(/\s/g, "_") + '">' + category + '</a>';
+        if (matchedLink.indexOf("Category:") === 0) {
+            var elem = '<span class="category">';
+            var colonIndex = matchedLink.indexOf(":");
+            var category = matchedLink.substring(colonIndex + 1);
+            var link = '<a href="' + constants.WIKIPEDIA_STUB + lang + constants.WIKIPEDIA_URL_WIKI + 'Category:' + category.replace(/\s/g, "_") + '">' + category + '</a>';
 
-      return elem + link + '</span>';
-    } else if (/\|/.test(matchedLink)) {
-      //TODO Use underscore to perform trimming
-      var splitLink = matchedLink.split("|");
-      matchedLink = splitLink[1];
-      underscoreLink = splitLink[0].replace(/\s/g, "_");
-    } else {
-      underscoreLink = matchedLink.replace(/\s/g, "_");
-    }
-
-    return '<a href="' + constants.WIKIPEDIA_EN_URL + '/wiki/' + underscoreLink + '">' + matchedLink + '</a>';
-  });
-
-
-  line = line.replace(SINGLE_BRACKET_LINK_REGEX, function(match, matchedLink){
-    if(matchedLink.indexOf("http://") === 0){
-      var firstSpaceIndex = matchedLink.indexOf(" ");
-      var link = matchedLink.substring(0, firstSpaceIndex);
-      var title = matchedLink.substring(firstSpaceIndex + 1);
-
-      return '<a href="' + link + '">' + title + "</a>";
-    }else{
-      return matchedLink;
-    }
-  });
-
-
-  line = line.replace(COMMENTS_REGEX, "");
-
-  line = line.replace(SPECIAL_LANGUAGE_INFO_REGEX, function (match, matchedLangStr) {
-    var splitInfo = matchedLangStr.split("|");
-    if (splitInfo.length > 0) {
-      //short circuit rightaway if we are dealing with a citation/reference
-      if (/cite/.test(splitInfo[0])) {
-        return "";
-      }
-      var langInfo = LANGUAGE_MAP[splitInfo[0]];
-      var prefix = "";
-      var suffix = "";
-
-      //Print the language information if it is present
-      if (langInfo) {
-        langInfo = langInfo ? langInfo + ": " : "";
-        prefix = langInfo;
-      } else {
-        prefix = "[";
-        suffix = "]"
-      }
-      var ret = prefix;
-      for (var i = 1; i < splitInfo.length; ++i) {
-        var curr = splitInfo[i];
-        if (!/links|IPA|icon/.test(curr)) {
-          ret += splitInfo[i];
+            return elem + link + '</span>';
+        } else if (/\|/.test(matchedLink)) {
+            //TODO Use underscore to perform trimming
+            var splitLink = matchedLink.split("|");
+            matchedLink = splitLink[1];
+            underscoreLink = splitLink[0].replace(/\s/g, "_");
+        } else {
+            underscoreLink = matchedLink.replace(/\s/g, "_");
         }
-      }
-      ret += suffix;
-      return ret;
-    } else {
-      return "";
-    }
-  });
 
-  line = line.replace(REFERENCE_REGEX, function (match, matchedAuthor) {
-    return "(ref: " + matchedAuthor + ")";
-  });
+        return '<a href="' + constants.WIKIPEDIA_STUB + lang + constants.WIKIPEDIA_URL + '/wiki/' + underscoreLink + '">' + matchedLink + '</a>';
+    });
 
-  line = line.replace(REFERENCES_TO_IGNORE, "");
 
-  return line;
+    line = line.replace(SINGLE_BRACKET_LINK_REGEX, function(match, matchedLink) {
+        if (matchedLink.indexOf("http://") === 0) {
+            var firstSpaceIndex = matchedLink.indexOf(" ");
+            var link = matchedLink.substring(0, firstSpaceIndex);
+            var title = matchedLink.substring(firstSpaceIndex + 1);
+
+            return '<a href="' + link + '">' + title + "</a>";
+        } else {
+            return matchedLink;
+        }
+    });
+
+
+    line = line.replace(COMMENTS_REGEX, "");
+
+    line = line.replace(SPECIAL_LANGUAGE_INFO_REGEX, function(match, matchedLangStr) {
+        var splitInfo = matchedLangStr.split("|");
+        if (splitInfo.length > 0) {
+            //short circuit rightaway if we are dealing with a citation/reference
+            if (/cite/.test(splitInfo[0])) {
+                return "";
+            }
+            var langInfo = LANGUAGE_MAP[splitInfo[0]];
+            var prefix = "";
+            var suffix = "";
+
+            //Print the language information if it is present
+            if (langInfo) {
+                langInfo = langInfo ? langInfo + ": " : "";
+                prefix = langInfo;
+            } else {
+                prefix = "[";
+                suffix = "]"
+            }
+            var ret = prefix;
+            for (var i = 1; i < splitInfo.length; ++i) {
+                var curr = splitInfo[i];
+                if (!/links|IPA|icon/.test(curr)) {
+                    ret += splitInfo[i];
+                }
+            }
+            ret += suffix;
+            return ret;
+        } else {
+            return "";
+        }
+    });
+
+    line = line.replace(REFERENCE_REGEX, function(match, matchedAuthor) {
+        return "(ref: " + matchedAuthor + ")";
+    });
+
+    line = line.replace(REFERENCES_TO_IGNORE, "");
+
+    return line;
 }
 
 

--- a/lib/parser/wikiParser.js
+++ b/lib/parser/wikiParser.js
@@ -1,110 +1,110 @@
 var _ = require("underscore"),
-  converter = require("./../converter/wikiToHTMLConverter");
+    converter = require("./../converter/wikiToHTMLConverter");
 
 _.str = require("underscore.string");
 _.mixin(_.str.exports());
 
-function parseJson(wiki, callback) {
-  if (wiki.query && wiki.query.pages) {
-    var keys = Object.keys(wiki.query.pages);
-    if (keys.length > 0) {
+function parseJson(wiki, lang, callback) {
+    if (wiki.query && wiki.query.pages) {
+        var keys = Object.keys(wiki.query.pages);
+        if (keys.length > 0) {
 
-      if (!wiki.query.pages[keys[0]].revisions) {
-        // page not found
-        callback(null, null);
-        return;
-      }
+            if (!wiki.query.pages[keys[0]].revisions) {
+                // page not found
+                callback(null, null);
+                return;
+            }
 
-      var metaDataCounter = 0;
-      //Take the first result
-      var latestArticle = wiki.query.pages[keys[0]].revisions[0]["*"];
-//      console.log(latestArticle);
-      var lines = latestArticle.split("\n");
-      var linesToParse = [];
-      var parsedText = "";
-      var sectionLines = [];
+            var metaDataCounter = 0;
+            //Take the first result
+            var latestArticle = wiki.query.pages[keys[0]].revisions[0]["*"];
+            //      console.log(latestArticle);
+            var lines = latestArticle.split("\n");
+            var linesToParse = [];
+            var parsedText = "";
+            var sectionLines = [];
 
-      lines.forEach(function (line) {
-        //Ignoring metadata information
-        var matchArray = line.match(/\{\{/g);
-        var openingDoubleCurlyBracketsCount = matchArray ? matchArray.length : 0;
+            lines.forEach(function(line) {
+                //Ignoring metadata information
+                var matchArray = line.match(/\{\{/g);
+                var openingDoubleCurlyBracketsCount = matchArray ? matchArray.length : 0;
 
-        matchArray = line.match(/\}\}/g);
-        var closingDoubleCurlyBracketsCount = matchArray ? matchArray.length : 0;
+                matchArray = line.match(/\}\}/g);
+                var closingDoubleCurlyBracketsCount = matchArray ? matchArray.length : 0;
 
-        if (openingDoubleCurlyBracketsCount > closingDoubleCurlyBracketsCount) {
-          ++metaDataCounter;
-        } else if (closingDoubleCurlyBracketsCount > openingDoubleCurlyBracketsCount) {
-          --metaDataCounter;
+                if (openingDoubleCurlyBracketsCount > closingDoubleCurlyBracketsCount) {
+                    ++metaDataCounter;
+                } else if (closingDoubleCurlyBracketsCount > openingDoubleCurlyBracketsCount) {
+                    --metaDataCounter;
+                }
+
+                if (metaDataCounter == 0 && !(_(line).startsWith("}}") ||
+                        _(line).startsWith("|") ||
+                        _(line).startsWith("{") ||
+                        _(line).startsWith("<") ||
+                        _(line).startsWith("[[File") ||
+                        _(line).startsWith("\n") ||
+                        line.length == 0)) {
+                    sectionLines.push(line);
+                }
+            });
+
+            //Add the section lines to the lines to parse array if it was not already done
+            if (linesToParse.length == 0) {
+                linesToParse.push(sectionLines);
+            }
+
+            linesToParse.forEach(function(sectionLines) {
+                var list = false;
+                sectionLines.forEach(function(line) {
+
+                    var convertedLine = converter.convertLineToHTML(line, lang);
+
+                    if (_(convertedLine).startsWith("*")) {
+                        if (!list) {
+                            list = true;
+                            parsedText += "<ul>\n";
+                        }
+                        parsedText += "<li>" + convertedLine.substring(1) + "</li>\n";
+                    } else if (_(convertedLine).startsWith("<h")) {
+                        if (list) {
+                            parsedText += "</ul>\n";
+                            list = false;
+                        }
+                        parsedText += convertedLine + "\n";
+                    } else {
+                        if (list) {
+                            parsedText += "</ul>\n";
+                            list = false;
+                        }
+                        parsedText += "<p>" + convertedLine + "</p>\n";
+                    }
+
+                });
+            });
+
+            process.nextTick(function() {
+                callback(null, parsedText);
+            });
+        } else {
+            process.nextTick(function() {
+                callback(null, null);
+            });
         }
-
-        if (metaDataCounter == 0 && !(_(line).startsWith("}}") ||
-                                      _(line).startsWith("|") ||
-                                      _(line).startsWith("{") ||
-                                      _(line).startsWith("<") ||
-                                      _(line).startsWith("[[File") ||
-                                      _(line).startsWith("\n") ||
-                                      line.length == 0)) {
-          sectionLines.push(line);
-        }
-      });
-
-      //Add the section lines to the lines to parse array if it was not already done
-      if (linesToParse.length == 0) {
-        linesToParse.push(sectionLines);
-      }
-
-      linesToParse.forEach(function (sectionLines) {
-        var list = false;
-        sectionLines.forEach(function (line) {
-
-          var convertedLine = converter.convertLineToHTML(line);
-
-          if(_(convertedLine).startsWith("*")){
-            if(!list){
-              list = true;
-              parsedText += "<ul>\n";
-            }
-            parsedText += "<li>" + convertedLine.substring(1) + "</li>\n";
-          }else if(_(convertedLine).startsWith("<h")){
-            if(list){
-              parsedText += "</ul>\n";
-              list = false;
-            }
-            parsedText += convertedLine + "\n";
-          }else{
-            if(list){
-              parsedText += "</ul>\n";
-              list = false;
-            }
-            parsedText += "<p>" + convertedLine + "</p>\n";
-          }
-
-        });
-      });
-
-      process.nextTick(function () {
-        callback(null, parsedText);
-      });
     } else {
-      process.nextTick(function () {
-        callback(null, null);
-      });
+        process.nextTick(function() {
+            callback(new Error("Unable to parse json"), null);
+        });
     }
-  } else {
-    process.nextTick(function () {
-      callback(new Error("Unable to parse json"), null);
-    });
-  }
 }
 
 
-module.exports.parse = function (wiki, format, callback) {
-  //if (format === "json") {
-    parseJson(wiki, callback);
-  //} else {
-  //  process.nextTick(function () {
-  //    callback(new Error("Unrecognized format [format=" + format + "]"));
-  //  });
-  //}
+module.exports.parse = function(wiki, format, lang, callback) {
+    //if (format === "json") {
+    parseJson(wiki, lang, callback);
+    //} else {
+    //  process.nextTick(function () {
+    //    callback(new Error("Unrecognized format [format=" + format + "]"));
+    //  });
+    //}
 };

--- a/lib/wikiClient.js
+++ b/lib/wikiClient.js
@@ -1,6 +1,6 @@
-var superAgent      = require("superagent"),
-    wikiParser      = require("./parser/wikiParser"),
-    wikiConstants   = require("./constants/wikiConstants");
+var superAgent = require("superagent"),
+    wikiParser = require("./parser/wikiParser"),
+    wikiConstants = require("./constants/wikiConstants");
 
 function searchArticle(queryAndOptions, callback) {
     var query = queryAndOptions.query;
@@ -8,34 +8,49 @@ function searchArticle(queryAndOptions, callback) {
         return callback(new Error("No search query was provided"));
     }
 
-    var format        = queryAndOptions.format || "json";
-    var summaryOnly     = queryAndOptions.summaryOnly;
-    var queryParams     = {action: "query", format: format, prop: "revisions",
-                           rvprop: "content", titles: query, redirects: 1};
-    
+    var format = queryAndOptions.format || "json";
+    var lang = queryAndOptions.lang || "en"; //default to english
+    var summaryOnly = queryAndOptions.summaryOnly;
+
+    var queryParams = {
+        action: "query",
+        format: format,
+        prop: "revisions",
+        rvprop: "content",
+        titles: query,
+        redirects: 1,
+    };
+
     if (queryAndOptions.format === "html") {
         queryParams.format = "json";
-    }    
-
-    if(summaryOnly){
-        queryParams.rvsection = 0;
     }
 
-    superAgent.get(wikiConstants.WIKIPEDIA_EN_API_URL)
+    if (summaryOnly) {
+        queryParams.rvsection = 0;
+    }
+    var url = wikiConstants.WIKIPEDIA_STUB + lang + wikiConstants.WIKIPEDIA_URL;
+
+    superAgent.get(url)
         .query(queryParams)
         .set("User-Agent", "Node.js wikipedia-js client (kenshiro@kenshiro.me)")
-        .end(function (res) {
+        .end(function(res) {
             if (res.ok) {
                 if (format === "html") {
                     var jsonData = JSON.parse(res.text);
-                    wikiParser.parse(jsonData, format, callback);                   
-                } else if (format in {yaml: 1, php: 1, txt: 1, dbg: 1, dump: 1}) {
+                    wikiParser.parse(jsonData, format, lang, callback);
+                } else if (format in {
+                        yaml: 1,
+                        php: 1,
+                        txt: 1,
+                        dbg: 1,
+                        dump: 1
+                    }) {
                     // it does not work yet!
                 } else {
                     return callback(null, res.text);
                 }
             } else {
-                process.nextTick(function () {
+                process.nextTick(function() {
                     return callback(new Error("Unexpected HTTP status received [status=" + res.status + "]"));
                 });
             }

--- a/lib/wikiClient.js
+++ b/lib/wikiClient.js
@@ -28,7 +28,7 @@ function searchArticle(queryAndOptions, callback) {
     if (summaryOnly) {
         queryParams.rvsection = 0;
     }
-    var url = wikiConstants.WIKIPEDIA_STUB + lang + wikiConstants.WIKIPEDIA_URL;
+    var url = wikiConstants.WIKIPEDIA_STUB + lang + wikiConstants.WIKIPEDIA_API_URL;
 
     superAgent.get(url)
         .query(queryParams)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wikipedia-js",
   "description": "A simple client to query wikipedia",
-  "version": "0.0.6",
+  "version": "https://github.com/MaxBittker/wikipedia-js/tarball/master",
   "keywords": ["wikipedia", "wiki", "client", "search", "node", "node.js"],
   "author": "kenshiro-o<kenshiro@kenshiro.me>",
   "main": "lib/wikiClient",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wikipedia-js",
   "description": "A simple client to query wikipedia",
-  "version": "https://github.com/MaxBittker/wikipedia-js/tarball/master",
+  "version": "0.0.7",
   "keywords": ["wikipedia", "wiki", "client", "search", "node", "node.js"],
   "author": "kenshiro-o<kenshiro@kenshiro.me>",
   "main": "lib/wikiClient",

--- a/test/wikiClientTest.js
+++ b/test/wikiClientTest.js
@@ -1,308 +1,435 @@
-var vows        = require("vows"),
-    wikiClient  = require("../lib/wikiClient"),
-    expect      = require("expect.js"),
-    _           = require("underscore");
+var vows = require("vows"),
+    wikiClient = require("../lib/wikiClient"),
+    expect = require("expect.js"),
+    _ = require("underscore");
 
 _.str = require("underscore.string");
 _.mixin(_.str.exports());
 
 vows.describe("Wikipedia search checks").addBatch({
 
-  // html
-  "When searching (in html) for Napoleon's wiki summary":{
-    topic: function(){
-      var options = {query: "Napoleon Bonaparte", format: "html", summaryOnly: true};
-      wikiClient.searchArticle(options, this.callback);
+    // html
+    "When searching (in html) for Napoleon's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "html",
+                summaryOnly: true
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(_(response).startsWith("<p><strong>Napoléon Bonaparte</strong>")).to.be(true);
+            // console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    "When searching (in html) for Napoleon's full wiki article": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "html"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(_(response).startsWith("<p><strong>Napoléon Bonaparte</strong>")).to.be(true);
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    "When searching (in html) for Albert Einstein's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Albert Einstein",
+                format: "html",
+                summaryOnly: true
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(_(response).startsWith("<p><strong>Albert Einstein</strong>")).to.be(true);
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    "When searching (in html) for Albert Einstein's full wiki article": {
+        topic: function() {
+            var options = {
+                query: "Albert Einstein",
+                format: "html"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(_(response).startsWith("<p><strong>Albert Einstein</strong>")).to.be(true);
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        },
+    },
+    "When searching (in html) for a wiki article with a single quote in the title": {
+        topic: function() {
+            var options = {
+                query: "Harry Potter and the Philosopher's Stone",
+                format: "html"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(_(response).startsWith("<p><strong><em>Harry Potter and the Philosopher's Stone</em></strong>")).to.be(true);
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    // end of html test
+
+
+    // json test:
+    "When searching (in json) for Napoleon's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "json",
+                summaryOnly: true
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            var json = JSON.parse(response);
+            expect(err).to.be(null);
+            expect(json.query.redirects[0].to).to.be("Napoleon");
+            //console.log(response);
+            //console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    "When searching (in json) for Napoleon's full wiki article": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "json"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            var json = JSON.parse(response);
+            expect(err).to.be(null);
+            expect(json.query.redirects[0].to).to.be("Napoleon");
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
     },
 
-    "A valid set of paragraphs is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(_(response).startsWith("<p><strong>Napoleon Bonaparte</strong>")).to.be(true);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in html) for Napoleon's full wiki article" :{
-    topic: function(){
-      var options = {query: "Napoleon Bonaparte", format: "html"};
-      wikiClient.searchArticle(options, this.callback);
+    "When searching (in json) for Albert Einstein's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Albert Einstein",
+                format: "json",
+                summaryOnly: true
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            var json = JSON.parse(response);
+            expect(err).to.be(null);
+            expect(json.query.pages["736"].title).to.be("Albert Einstein");
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    "When searching (in json) for Albert Einstein's full wiki article": {
+        topic: function() {
+            var options = {
+                query: "Albert Einstein",
+                format: "json"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            var json = JSON.parse(response);
+            expect(err).to.be(null);
+            expect(json.query.pages["736"].title).to.be("Albert Einstein");
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    }, // end of json test
+
+    // xml test:
+    "When searching (in xml) for Napoleon's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "xml",
+                summaryOnly: true
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf('title="Napoleon"')).to.be.above(0);
+            //console.log(response);
+            //console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    "When searching (in xml) for Napoleon's full wiki article": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "xml"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf('title="Napoleon"')).to.be.above(0);
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
     },
 
-    "A valid full article is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(_(response).startsWith("<p><strong>Napoleon Bonaparte</strong>")).to.be(true);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in html) for Albert Einstein's wiki summary":{
-    topic: function(){
-      var options = {query: "Albert Einstein", format: "html", summaryOnly: true};
-      wikiClient.searchArticle(options, this.callback);
+    "When searching (in xml) for Albert Einstein's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Albert Einstein",
+                format: "xml",
+                summaryOnly: true
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf('title="Albert Einstein"')).to.be.above(0);
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    "When searching (in xml) for Albert Einstein's full wiki article": {
+        topic: function() {
+            var options = {
+                query: "Albert Einstein",
+                format: "xml"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf('title="Albert Einstein"')).to.be.above(0);
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    }, // end of xml test
+
+
+
+    // rawfm test:
+    "When searching (in rawfm) for Napoleon's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "rawfm",
+                summaryOnly: true
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf("&quot;Napoleon&quot;")).to.be.above(0);
+            // console.log(response);
+            //console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    "When searching (in rawfm) for Napoleon's full wiki article": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "rawfm"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf("''Napoleone di Buonaparte''; ")).to.be.above(0);
+            // console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
     },
 
-    "A valid set of paragraphs is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(_(response).startsWith("<p><strong>Albert Einstein</strong>")).to.be(true);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in html) for Albert Einstein's full wiki article":{
-    topic: function(){
-      var options = {query: "Albert Einstein", format: "html"};
-      wikiClient.searchArticle(options, this.callback);
+    "When searching (in rawfm) for Albert Einstein's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Albert Einstein",
+                format: "rawfm",
+                summaryOnly: true
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf("&quot;Albert Einstein&quot;")).to.be.above(0);
+            // console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    "When searching (in rawfm) for Albert Einstein's full wiki article": {
+        topic: function() {
+            var options = {
+                query: "Albert Einstein",
+                format: "rawfm"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf("|title=Albert Einstein")).to.be.above(0);
+            // console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    }, // end of rawfm test
+    // xml test:
+    "When searching (in xml) for Napoleon's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "xml",
+                summaryOnly: true
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf('title="Napoleon"')).to.be.above(0);
+            //console.log(response);
+            //console.log("*************************************************************************************\n\n\n\n");
+        }
+    },
+    "When searching (in xml) for Napoleon's full wiki article": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "xml"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf('title="Napoleon"')).to.be.above(0);
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
     },
 
-    "A valid full article is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(_(response).startsWith("<p><strong>Albert Einstein</strong>")).to.be(true);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
+    "When searching (in xml) for Albert Einstein's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Albert Einstein",
+                format: "xml",
+                summaryOnly: true
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf('title="Albert Einstein"')).to.be.above(0);
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
     },
-  },
-  "When searching (in html) for a wiki article with a single quote in the title":{
-    topic: function(){
-      var options = {query: "Harry Potter and the Philosopher's Stone", format: "html"};
-      wikiClient.searchArticle(options, this.callback);
+    "When searching (in xml) for Albert Einstein's full wiki article": {
+        topic: function() {
+            var options = {
+                query: "Albert Einstein",
+                format: "xml"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid full article is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf('title="Albert Einstein"')).to.be.above(0);
+            //      console.log(response);
+            //      console.log("*************************************************************************************\n\n\n\n");
+        }
+    }, // end of xml test
+
+    // language test:
+    "When searching (in simple english) for Napoleon's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "html",
+                summaryOnly: true,
+                lang: "simple"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
+
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf("His actions")).to.be.above(0);
+            // console.log(response);
+            //console.log("*************************************************************************************\n\n\n\n");
+        }
     },
+    "When searching (in chinese) for 1美元金币 wiki summary": {
+        topic: function() {
+            var options = {
+                query: "1美元金币",
+                format: "html",
+                summaryOnly: true,
+                lang: "zh"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
 
-    "A valid full article is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(_(response).startsWith("<p><strong><em>Harry Potter and the Philosopher's Stone</em></strong>")).to.be(true);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  // end of html test
-
-
-  // json test:
-  "When searching (in json) for Napoleon's wiki summary":{
-    topic: function(){
-      var options = {query: "Napoleon Bonaparte", format: "json", summaryOnly: true};
-      wikiClient.searchArticle(options, this.callback);
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            expect(response.indexOf("从直径来看")).to.be.above(0);
+            // console.log(response);
+            //console.log("*************************************************************************************\n\n\n\n");
+        }
     },
+    "When searching (in french) for Napoleon's wiki summary": {
+        topic: function() {
+            var options = {
+                query: "Napoleon Bonaparte",
+                format: "html",
+                summaryOnly: true,
+                lang: "fr"
+            };
+            wikiClient.searchArticle(options, this.callback);
+        },
 
-    "A valid set of paragraphs is returned": function(err, response){
-      var json = JSON.parse(response);
-      expect(err).to.be(null);
-      expect(json.query.redirects[0].to).to.be("Napoleon");
-      //console.log(response);
-      //console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in json) for Napoleon's full wiki article" :{
-    topic: function(){
-      var options = {query: "Napoleon Bonaparte", format: "json"};
-      wikiClient.searchArticle(options, this.callback);
-    },
+        "A valid set of paragraphs is returned": function(err, response) {
+            expect(err).to.be(null);
+            // console.log(response);
+            expect(response.indexOf("né le")).to.be.above(0);
+            //console.log("*************************************************************************************\n\n\n\n");
+        }
+    } // end of language test
 
-    "A valid full article is returned": function(err, response){
-      var json = JSON.parse(response);
-      expect(err).to.be(null);
-      expect(json.query.redirects[0].to).to.be("Napoleon");
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-
-  "When searching (in json) for Albert Einstein's wiki summary":{
-    topic: function(){
-      var options = {query: "Albert Einstein", format: "json", summaryOnly: true};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid set of paragraphs is returned": function(err, response){
-      var json = JSON.parse(response);
-      expect(err).to.be(null);
-      expect(json.query.pages["736"].title).to.be("Albert Einstein");
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in json) for Albert Einstein's full wiki article":{
-    topic: function(){
-      var options = {query: "Albert Einstein", format: "json"};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid full article is returned": function(err, response){
-      var json = JSON.parse(response);
-      expect(err).to.be(null);
-      expect(json.query.pages["736"].title).to.be("Albert Einstein");
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  }, // end of json test
-
-
-  // wddx test:
-  "When searching (in wddx) for Napoleon's wiki summary":{
-    topic: function(){
-      var options = {query: "Napoleon Bonaparte", format: "wddx", summaryOnly: true};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid set of paragraphs is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf("<var name='to'><string>Napoleon</string></var>")).to.be.above(0);
-      //console.log(response);
-      //console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in wddx) for Napoleon's full wiki article" :{
-    topic: function(){
-      var options = {query: "Napoleon Bonaparte", format: "wddx"};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid full article is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf("<var name='to'><string>Napoleon</string></var>")).to.be.above(0);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-
-  "When searching (in wddx) for Albert Einstein's wiki summary":{
-    topic: function(){
-      var options = {query: "Albert Einstein", format: "wddx", summaryOnly: true};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid set of paragraphs is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf("<var name='title'><string>Albert Einstein</string></var>")).to.be.above(0);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in wddx) for Albert Einstein's full wiki article":{
-    topic: function(){
-      var options = {query: "Albert Einstein", format: "wddx"};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid full article is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf("<var name='title'><string>Albert Einstein</string></var>")).to.be.above(0);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },// end of wddx test
-
-
-  // xml test:
-  "When searching (in xml) for Napoleon's wiki summary":{
-    topic: function(){
-      var options = {query: "Napoleon Bonaparte", format: "xml", summaryOnly: true};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid set of paragraphs is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf('title="Napoleon"')).to.be.above(0);
-      //console.log(response);
-      //console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in xml) for Napoleon's full wiki article" :{
-    topic: function(){
-      var options = {query: "Napoleon Bonaparte", format: "xml"};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid full article is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf('title="Napoleon"')).to.be.above(0);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-
-  "When searching (in xml) for Albert Einstein's wiki summary":{
-    topic: function(){
-      var options = {query: "Albert Einstein", format: "xml", summaryOnly: true};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid set of paragraphs is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf('title="Albert Einstein"')).to.be.above(0);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in xml) for Albert Einstein's full wiki article":{
-    topic: function(){
-      var options = {query: "Albert Einstein", format: "xml"};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid full article is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf('title="Albert Einstein"')).to.be.above(0);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },// end of xml test
-
-
-
-  // rawfm test:
-  "When searching (in rawfm) for Napoleon's wiki summary":{
-    topic: function(){
-      var options = {query: "Napoleon Bonaparte", format: "rawfm", summaryOnly: true};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid set of paragraphs is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf("&quot;title&quot;: &quot;Napoleon&quot;")).to.be.above(0);
-      //console.log(response);
-      //console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in rawfm) for Napoleon's full wiki article" :{
-    topic: function(){
-      var options = {query: "Napoleon Bonaparte", format: "rawfm"};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid full article is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf("&quot;title&quot;: &quot;Napoleon&quot;")).to.be.above(0);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-
-  "When searching (in rawfm) for Albert Einstein's wiki summary":{
-    topic: function(){
-      var options = {query: "Albert Einstein", format: "rawfm", summaryOnly: true};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid set of paragraphs is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf("&quot;title&quot;: &quot;Albert Einstein&quot;")).to.be.above(0);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  },
-  "When searching (in rawfm) for Albert Einstein's full wiki article":{
-    topic: function(){
-      var options = {query: "Albert Einstein", format: "rawfm"};
-      wikiClient.searchArticle(options, this.callback);
-    },
-
-    "A valid full article is returned": function(err, response){
-      expect(err).to.be(null);
-      expect(response.indexOf("&quot;title&quot;: &quot;Albert Einstein&quot;")).to.be.above(0);
-//      console.log(response);
-//      console.log("*************************************************************************************\n\n\n\n");
-    }
-  }// end of rawfm test
 
 }).run();


### PR DESCRIPTION
This pull request implements a new argument 'lang' which allows you to query all 288 Wikipedia languages!  Defaults to English which means it's also backwards compatible.
I also fixed the tests which were broken due to some pages changing their wording, and the wddx api being deprecated. I don't know why travis is currently reporting build passing, because about half of the test failed on my machine when I first cloned. 
I apologize for the formatting changes, I use a popular javascript formatter and forgot I had it on. 

Thanks for putting out this package! I've been using it to train my neural network.